### PR TITLE
Don’t attempt to parse JWT token unless explicitly asked.

### DIFF
--- a/lib/real_savvy/jwt/abstract_token.rb
+++ b/lib/real_savvy/jwt/abstract_token.rb
@@ -4,21 +4,18 @@ module RealSavvy
       # In order of access level
       SCOPE_VERBS = %w{public read write admin}.freeze
 
-      attr_reader :scopes, :user, :site, :token, :header, :claims
+      attr_reader :token
 
       def initialize(token)
         @token = token
         standardized_token
-        retrieve_claims
-        retrieve_scopes
-        retrieve_audience
-        retrieve_site
-        retrieve_subject
-        retrieve_user
       end
 
+      # New token, plus makes sure there isn't any errors with the token
       def self.decode(token)
-        new(token)
+        new(token).tap do |new_token|
+          new_token.valid?
+        end
       end
 
       def scope_includes?(*scope_parts)
@@ -90,6 +87,7 @@ module RealSavvy
       end
 
       def imposter?
+        user
         @imposter ? true : false
       end
 
@@ -97,43 +95,53 @@ module RealSavvy
         @token.split('.')[1]
       end
 
-      private
+      def claims
+        retrieve_claims unless @claims
+        @claims
+      end
 
-      attr_reader :audience, :subject
+      def header
+        retrieve_claims unless @header
+        @header
+      end
+
+      def site
+        audience
+      end
+
+      def user
+        @user ||= begin
+                    if subject_is_user?
+                      subject
+                    elsif subject_is_imposter?
+                      @imposter = true
+                      subject.user
+                    end
+                  end
+      end
+
+      def scopes
+        @scopes ||= raw_scopes.each_with_object({}) do |scope, result|
+          scope.split(':').inject(result) { |m, v| m[v] ||= {} }
+        end
+      end
+
+      private
 
       def retrieve_claims
         raise NotImplementedError, "subclass did not define #retrieve_claims"
       end
 
-      def retrieve_audience
-        @audience = ::RealSavvy::JWT::Config.retrieve_audience(self) if claims && claims['aud']
+      def audience
+        @audience ||= ::RealSavvy::JWT::Config.retrieve_audience(self) if claims && claims['aud']
       end
 
-      def retrieve_subject
-        @subject = ::RealSavvy::JWT::Config.retrieve_subject(self) if claims && claims['sub']
-      end
-
-      def retrieve_site
-        @site = audience
-      end
-
-      def retrieve_user
-        if subject_is_user?
-          @user = subject
-        elsif subject_is_imposter?
-          @user = subject.user
-          @imposter = true
-        end
+      def subject
+        @subject ||= ::RealSavvy::JWT::Config.retrieve_subject(self) if claims && claims['sub']
       end
 
       def raw_scopes
         claims&.fetch('scopes', nil).to_a
-      end
-
-      def retrieve_scopes
-        @scopes = raw_scopes.each_with_object({}) do |scope, result|
-          scope.split(':').inject(result) { |m, v| m[v] ||= {} }
-        end
       end
 
       def standardized_token

--- a/lib/real_savvy/jwt/config.rb
+++ b/lib/real_savvy/jwt/config.rb
@@ -5,6 +5,7 @@ module RealSavvy
         if block_given?
           @public_key = Proc.new
         else
+          raise NotImplementedError, "public_key not provided" unless @public_key
           result = @public_key.is_a?(Proc) ? @public_key.call : @public_key
           result.is_a?(OpenSSL::PKey::RSA) ? result : OpenSSL::PKey::RSA.new(result)
         end
@@ -18,6 +19,7 @@ module RealSavvy
         if block_given?
           @retrieve_audience = Proc.new
         else
+          raise NotImplementedError, "retrieve_audience logic not implemeted" unless @retrieve_audience
           @retrieve_audience.call(token)
         end
       end
@@ -30,6 +32,7 @@ module RealSavvy
         if block_given?
           @retrieve_subject = Proc.new
         else
+          raise NotImplementedError, "retrieve_subject logic not implemeted" unless @retrieve_subject
           @retrieve_subject.call(token)
         end
       end
@@ -42,6 +45,7 @@ module RealSavvy
         if block_given?
           @validate_token = Proc.new
         else
+          raise NotImplementedError, "validate_token logic not implemeted" unless @validate_token
           @validate_token.call(token)
         end
       end

--- a/spec/real_savvy_spec.rb
+++ b/spec/real_savvy_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe RealSavvy do
+  it 'raise errors if configs not set' do
+    old_public_key = RealSavvy::JWT::Config.public_key
+    RealSavvy::JWT::Config.public_key = nil
+    expect{ RealSavvy::JWT::Config.public_key }.to raise_error(NotImplementedError)
+    RealSavvy::JWT::Config.public_key = old_public_key
+    expect{ RealSavvy::JWT::Config.retrieve_audience('foobar') }.to raise_error(NotImplementedError)
+    expect{ RealSavvy::JWT::Config.retrieve_subject('foobar') }.to raise_error(NotImplementedError)
+    expect{ RealSavvy::JWT::Config.validate_token('foobar') }.to raise_error(NotImplementedError)
+  end
+
   it 'can get each adapter behind a proxy form the client' do
     RealSavvy::Client::ADAPTER_LOOKUP.each do |method, adapter|
       expect(client.send(method)).to be_a(RealSavvy::Client::AdapterProxy)


### PR DESCRIPTION
Raise error if configs are not set, and actions requiring them are used.