### PR TITLE
RT-998 - Upgrade to circle 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:


### PR DESCRIPTION
Circle is forcing all projects to use their pipeline feature.  This is getting ahead of that.  Refer to https://circleci.com/docs/2.0/build-processing/#getting-started for details.

Also refer to https://ojolabs.atlassian.net/browse/RT-994